### PR TITLE
fix: download url platform mapping for aarch64 -> arm64

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -32,6 +32,9 @@ get_arch() {
     x86_64|amd64)
       echo "x64"
       ;;
+    aarch64)
+      echo "arm64"
+      ;;
     *)
       echo "$arch"
       ;;


### PR DESCRIPTION
# Fix ARM download URL mapping for opencode
## Motivation

The opencode release artifacts use `arm64` in their download URLs, but the plugin was mapping the ARM architecture as `aarch64`. This mismatch caused install failures on ARM-based systems.

## Contents

* Added a case to map `aarch64` → `arm64` when resolving the opencode download URL.